### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The charts should work with older versions with minor changes.
 
 Usage
 =============
-There are two charts currently implemented - markers and choropleth. They extend the base abstract leaflet chart. Both support selection of datapoints and update in real time. Styling and map options can be set directly to the map object and though functions in the chart. Check the [Leaflet reference](http://leafletjs.com/reference.html#map-options) for more information on the specific map, marker and geojson options.
+There are three charts currently implemented - marker, choropleth, and bubble. They extend the base abstract leaflet chart. Both support selection of datapoints and update in real time. Styling and map options can be set directly to the map object and though functions in the chart. Check the [Leaflet reference](http://leafletjs.com/reference.html#map-options) for more information on the specific map, marker and geojson options.
 Location can be set as either 'lat,lng' string or as an array [lat,lng].
 
 Leaflet base


### PR DESCRIPTION
The dc.leaflet documentation describes the chart types available for implementation. The usage section lists two, but the subsequent section appears to show that three are available. This PR modifies the language by updating "Usage" paragraph to note inclusion of "Bubble" chart